### PR TITLE
Calculate usec duration differently

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -1,0 +1,30 @@
+name: Ruby Gem
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+
+    - name: Publish to GPR
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: Bearer ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.GPR_AUTH_TOKEN}}
+        OWNER: cat-home-experts

--- a/lib/rack/ougai/log_requests.rb
+++ b/lib/rack/ougai/log_requests.rb
@@ -24,7 +24,7 @@ module Rack
 
         ret = {
           time: @local ? start_time : start_time.utc,
-          usec: end_time.usec - start_time.usec,
+          usec: (end_time.to_f - start_time.to_f) * 10**6,
           remote_addr: env['HTTP_X_FORWARDED_FOR'] || env["REMOTE_ADDR"],
           method: env[REQUEST_METHOD],
           path: env[PATH_INFO],

--- a/lib/rack/ougai/log_requests.rb
+++ b/lib/rack/ougai/log_requests.rb
@@ -19,7 +19,7 @@ module Rack
 
       private
 
-      def create_log(start_time, env, status, _headers)
+      def create_log(start_time, env, status, headers)
         end_time = Time.now
 
         ret = {
@@ -34,6 +34,8 @@ module Rack
 
         request_id = env['HTTP_X_REQUEST_ID']
         ret[:request_id] = request_id unless request_id.nil?
+        content_version = headers['Content-Version']
+        ret[:content_version] = content_version unless content_version.nil?
 
         ret
       end

--- a/lib/rack/ougai/version.rb
+++ b/lib/rack/ougai/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module Ougai
-    VERSION = "0.2.2-pre1".freeze
+    VERSION = "0.2.2".freeze
   end
 end

--- a/lib/rack/ougai/version.rb
+++ b/lib/rack/ougai/version.rb
@@ -1,5 +1,5 @@
 module Rack
   module Ougai
-    VERSION = "0.2.1".freeze
+    VERSION = "0.2.2-pre1".freeze
   end
 end


### PR DESCRIPTION
Ruby usec function only gives the microsecond component of the time and
not the time representation within microseconds. See the example below
from ruby-doc [1]:

```ruby
t = Time.now        #=> 2007-11-19 08:03:26 -0600
"%10.6f" % t.to_f   #=> "1195481006.775195"
t.usec              #=> 775195
```

[1] https://ruby-doc.org/core-2.6.2/Time.html#method-i-usec